### PR TITLE
Remove integer:true property

### DIFF
--- a/problems/override/seneca-override-executor-run.js
+++ b/problems/override/seneca-override-executor-run.js
@@ -6,7 +6,7 @@
 var seneca = require('seneca')()
 seneca.use(process.argv[2])
 
-seneca.act({role: 'math', cmd: 'sum', integer: true, left: process.argv[3], right: process.argv[4]}, function (err, result) {
+seneca.act({role: 'math', cmd: 'sum', left: process.argv[3], right: process.argv[4]}, function (err, result) {
   if (err) return console.error(err)
   console.log(result)
 })


### PR DESCRIPTION
According to commit cecbaac, integer:true property is removed from executor.
