### PR TITLE
Log to stdout so that the test doesn't pass if there is an error.

### DIFF
--- a/problems/override/seneca-override-executor-run.js
+++ b/problems/override/seneca-override-executor-run.js
@@ -11,6 +11,6 @@ var seneca = require('seneca')()
 seneca.use(process.argv[2])
 
 seneca.act({role: 'math', cmd: 'sum', left: process.argv[3], right: process.argv[4]}, function (err, result) {
-  if (err) return console.error(err)
+  if (err) return console.log(err)
   console.log(result)
 })

--- a/problems/override/seneca-override-executor.js
+++ b/problems/override/seneca-override-executor.js
@@ -19,6 +19,6 @@ seneca.act({role: 'math', cmd: 'sum', left: 'michele', right: 2.5}, function (er
 })
 
 seneca.act({role: 'math', cmd: 'sum', left: process.argv[3], right: process.argv[4]}, function (err, result) {
-  if (err) return console.error(err)
+  if (err) return console.log(err)
   console.log(result)
 })


### PR DESCRIPTION
If you used Random.isFinite in the accompanying exercise, it would
trigger an error that was ignored because verify would pass anyway
before this patch.
