### PR TITLE
Fix unfair verification in "override" problem; revert Number patch from

### DIFF
--- a/problems/override/seneca-override-executor-run.js
+++ b/problems/override/seneca-override-executor-run.js
@@ -10,7 +10,7 @@
 var seneca = require('seneca')()
 seneca.use(process.argv[2])
 
-seneca.act({role: 'math', cmd: 'sum', left: process.argv[3], right: process.argv[4]}, function (err, result) {
+seneca.act({role: 'math', cmd: 'sum', left: parseInt(process.argv[3]), right: parseInt(process.argv[4])}, function (err, result) {
   if (err) return console.log(err)
   console.log(result)
 })

--- a/problems/override/seneca-override-executor.js
+++ b/problems/override/seneca-override-executor.js
@@ -18,7 +18,7 @@ seneca.act({role: 'math', cmd: 'sum', left: 'michele', right: 2.5}, function (er
   return console.log('false')
 })
 
-seneca.act({role: 'math', cmd: 'sum', left: process.argv[3], right: process.argv[4]}, function (err, result) {
+seneca.act({role: 'math', cmd: 'sum', left: parseInt(process.argv[3]), right: parseInt(process.argv[4])}, function (err, result) {
   if (err) return console.log(err)
   console.log(result)
 })

--- a/problems/override/solution/solution.js
+++ b/problems/override/solution/solution.js
@@ -1,6 +1,6 @@
 module.exports = function math (options) {
   this.add({role: 'math', cmd: 'sum'}, (msg, respond) => {
-    var sum = Number(msg.left) + Number(msg.right)
+    var sum = msg.left + msg.right
     respond(null, {answer: sum})
   })
 


### PR DESCRIPTION
e639d8a85f0f120965638b783978b4f9be6df831.

In the earlier "client" exercise you are told to transform the
process.argv argument into numbers. This suggests doing it in the client
(rather than in the plugin); and in fact the solution does just that.

As such, our plugin code expects the service client to take care of the
transformation, which leads to a problem in the "override" exercise,
where the verifier suddenly supplies number strings. The original
solution was to patch up the sum function and that's probably not a bad
idea in general, but it distracts from what's being taught. This patch
has the verifier use either (non-numerical) strings or proper numbers.
