### PR TITLE
Fix presumption in comparision used by 'sum', 'extend', and 'roles' exercises

### DIFF
--- a/problems/extend/exercise.js
+++ b/problems/extend/exercise.js
@@ -5,7 +5,7 @@ const fs = require('fs')
 const path = require('path')
 const async = require('async')
 const _ = require('lodash')
-const {getRandomFloat} = require('../utils')
+const {getRandomFloat, pickStaticProps} = require('../utils')
 let exercise = require('workshopper-exercise')()
 
 // cleanup for both run and verify
@@ -47,11 +47,11 @@ exercise.addProcessor(function (mode, callback) {
       cb()
     }
   ], (err, results) => {
-    submissionResult = results[0]
+    submissionResult = pickStaticProps(results[0])
     if (mode === 'run') {
       console.log(`Execution with left: ${a}, right: ${b} returned: ${JSON.stringify(submissionResult)}`)
     } else {
-      solutionResult = results[1]
+      solutionResult = pickStaticProps(results[1])
       if (!_.isEqual(solutionResult, submissionResult)) {
         exercise.emit('fail', `Expected result: ${JSON.stringify(solutionResult)}` +
                               `, Actual result: ${JSON.stringify(submissionResult)}`)

--- a/problems/roles/exercise.js
+++ b/problems/roles/exercise.js
@@ -5,7 +5,7 @@ const fs = require('fs')
 const path = require('path')
 const async = require('async')
 const _ = require('lodash')
-const {getRandomInt} = require('../utils')
+const {getRandomInt, pickStaticProps} = require('../utils')
 let exercise = require('workshopper-exercise')()
 
 // cleanup for both run and verify
@@ -47,11 +47,11 @@ exercise.addProcessor(function (mode, callback) {
       cb()
     }
   ], (err, results) => {
-    submissionResult = results[0]
+    submissionResult = pickStaticProps(results[0])
     if (mode === 'run') {
       console.log(`Execution with left: ${a}, right: ${b} returned: ${JSON.stringify(submissionResult)}`)
     } else {
-      solutionResult = results[1]
+      solutionResult = pickStaticProps(results[1])
       if (!_.isEqual(solutionResult, submissionResult)) {
         exercise.emit('fail', `Expected result: ${JSON.stringify(solutionResult)}` +
                               `, Actual result: ${JSON.stringify(submissionResult)}`)

--- a/problems/sum/exercise.js
+++ b/problems/sum/exercise.js
@@ -5,7 +5,7 @@ const fs = require('fs')
 const path = require('path')
 const async = require('async')
 const _ = require('lodash')
-const {getRandomInt} = require('../utils')
+const {getRandomInt, pickStaticProps} = require('../utils')
 let exercise = require('workshopper-exercise')()
 
 // cleanup for both run and verify
@@ -46,11 +46,11 @@ exercise.addProcessor(function (mode, callback) {
       cb()
     }
   ], (err, results) => {
-    submissionResult = results[0]
+    submissionResult = pickStaticProps(results[0])
     if (mode === 'run') {
       console.log(`Execution with left: ${a}, right: ${b} returned: ${JSON.stringify(submissionResult)}`)
     } else {
-      solutionResult = results[1]
+      solutionResult = pickStaticProps(results[1])
       if (!_.isEqual(solutionResult, submissionResult)) {
         exercise.emit('fail', `Expected result: ${JSON.stringify(solutionResult)}` +
                               `, Actual result: ${JSON.stringify(submissionResult)}`)

--- a/problems/utils.js
+++ b/problems/utils.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const _ = require('lodash')
+
 exports.getRandomInt = (min = 0, max = 100) => {
   min = Math.ceil(min)
   max = Math.floor(max)
@@ -12,3 +14,13 @@ exports.getRandomFloat = (min = 0, max = 100) => {
   const num = Math.floor(Math.random() * (max - min)) + min
   return Math.round(num * 10) / 100
 }
+
+exports.pickStaticProps = (result) => {
+  const staticProps = [
+    'pattern', 'action', 'tag', 'seneca', 'version', 'timeout', 'custon', 'plugin', 'parents',
+    'remote', 'sync', 'trace', 'sub', 'data', 'err', 'err_trace', 'error', 'empty'
+  ]
+  result[1] = _.pick(result[1], staticProps)
+  return result
+}
+

--- a/problems/utils.js
+++ b/problems/utils.js
@@ -20,7 +20,7 @@ exports.pickStaticProps = (result) => {
     'pattern', 'action', 'tag', 'seneca', 'version', 'timeout', 'custon', 'plugin', 'parents',
     'remote', 'sync', 'trace', 'sub', 'data', 'err', 'err_trace', 'error', 'empty'
   ]
-  result[1] = _.pick(result[1], staticProps)
-  return result
+
+  return [result[0], _.pick(result[1], staticProps)]
 }
 

--- a/problems/utils.js
+++ b/problems/utils.js
@@ -21,6 +21,10 @@ exports.pickStaticProps = (result) => {
     'remote', 'sync', 'trace', 'sub', 'data', 'err', 'err_trace', 'error', 'empty'
   ]
 
-  return [result[0], _.pick(result[1], staticProps)]
+  if (result && result.length >= 2) {
+    return [result[0], _.pick(result[1], staticProps)]
+  } else {
+    return result
+  }
 }
 

--- a/problems/utils.js
+++ b/problems/utils.js
@@ -17,7 +17,7 @@ exports.getRandomFloat = (min = 0, max = 100) => {
 
 exports.pickStaticProps = (result) => {
   const staticProps = [
-    'pattern', 'action', 'tag', 'seneca', 'version', 'timeout', 'custon', 'plugin', 'parents',
+    'pattern', 'tag', 'seneca', 'version', 'timeout', 'custon', 'parents',
     'remote', 'sync', 'trace', 'sub', 'data', 'err', 'err_trace', 'error', 'empty'
   ]
 


### PR DESCRIPTION
This fixes #106 "Sum Verification Problem"

In fact, it's not just the "sum" problem that is broken, but also "extend" and "roles".

The solution comparision relies on the output of the exercise being identical to the output of the official solution.  However, seneca responds with various "meta" fields, such as the timestamps "start" and "end" which can be expected to be different with every call.  Presumably these particular "meta" fields did not exist at the time the tutorial was written.  To restore desired function and correctly compare the results we pick just the fields from the 'meta' object that do stay the same.

I have sucessfully completed the course, and as such believe I have removed all the bugs preventing students from doing so.